### PR TITLE
Compatibility update with the latest postcode-nl/api-magento2-module version

### DIFF
--- a/Model/Resolver/AddressDetails.php
+++ b/Model/Resolver/AddressDetails.php
@@ -12,8 +12,8 @@
 
 namespace Experius\PostcodeGraphQl\Model\Resolver;
 
-use Experius\Core\Helper\Settings;
-use Flekto\Postcode\Helper\PostcodeApiClient;
+use Flekto\Postcode\Helper\StoreConfigHelper;
+use Flekto\Postcode\Service\PostcodeApiClient;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
@@ -29,11 +29,11 @@ class AddressDetails implements ResolverInterface
      * @param Settings $helper
      */
     public function __construct(
-        Settings $helper
+        StoreConfigHelper $helper
     ) {
         $this->postcodeHelper = new PostcodeApiClient(
-            $helper->getConfigValue('postcodenl_api/general/api_key'),
-            $helper->getConfigValue('postcodenl_api/general/api_secret')
+            $helper->getValue(StoreConfigHelper::PATH['api_key']),
+            $helper->getValue(StoreConfigHelper::PATH['api_secret'])
         );
     }
 

--- a/Model/Resolver/Postcode.php
+++ b/Model/Resolver/Postcode.php
@@ -12,9 +12,9 @@
 
 namespace Experius\PostcodeGraphQl\Model\Resolver;
 
-use Experius\Core\Helper\Settings;
-use Flekto\Postcode\Helper\Exception\ClientException;
-use Flekto\Postcode\Helper\PostcodeApiClient;
+use Flekto\Postcode\Helper\StoreConfigHelper;
+use Flekto\Postcode\Service\Exception\ClientException;
+use Flekto\Postcode\Service\PostcodeApiClient;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
@@ -33,11 +33,11 @@ class Postcode implements ResolverInterface
      * @param PostcodeApiClient $postcodeHelper
      */
     public function __construct(
-        Settings $helper
+        StoreConfigHelper $helper
     ) {
         $this->postcodeHelper = new PostcodeApiClient(
-            $helper->getConfigValue('postcodenl_api/general/api_key'),
-            $helper->getConfigValue('postcodenl_api/general/api_secret')
+            $helper->getValue(StoreConfigHelper::PATH['api_key']),
+            $helper->getValue(StoreConfigHelper::PATH['api_secret'])
         );
     }
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Experius_PostcodeGraphQl">
         <sequence>
-            <module name="Experius_Postcode"/>
+            <module name="Flekto_Postcode"/>
             <module name="Magento_GraphQl"/>
         </sequence>
     </module>


### PR DESCRIPTION
I've removed the need for the Experius\Core helper class that I couldn't find anywhere. 

It also seems that the postcode-nl/api-magento2-module version package doesn't have a iso2 to iso3 country code converter anymore. So now the default Magento country directory class is used instead. 

I haven't checked the autocomplete performance though. In the earlier version of postcode-nl/api-magento2-module version the iso2 to iso3 conversion was happening from a hard-coded array in the PHP code. The Magento country directory class pulls the country code data from the DB. So the performance is probably impacted by this change